### PR TITLE
Dashboard updates

### DIFF
--- a/dashboard/aggregate.py
+++ b/dashboard/aggregate.py
@@ -123,7 +123,7 @@ def app():
     
     st.subheader('Monetary bail posted')
     st.write("In nearly half (49%) of cases where monetary bail was set, bail was not posted, meaning that the defendant was not released from jail. Out of the cases where bail was at least $100,000, less than a quarter of defendants posted bail. Though infrequently set, bail amounts below $1000 were also infrequently posted.")
-    st.write("**<font color='red'>Question for PBF</font>**: do these observations (in particular, low payments of bail set below $1000) match your experience?", unsafe_allow_html=True), 
+    st.write("**<font color='red'>Question for PBF</font>**: do these observations (in particular, low payments of bail set below $1000) match your experience?", unsafe_allow_html=True)
     st.image(Image.open('figures/aggregate_bailPostedBin.png'), width=400)
     st.write("When bail was posted, the median and most frequently paid amount was $2,500 (corresponding to 10% of bail set at $25,000). ")
     st.image(Image.open('figures/aggregate_bailPosted.png'), width=400)    
@@ -161,7 +161,7 @@ def app():
     # Moving average plots 
     # ----------------------------------------------------
     st.subheader('Bail trends over the year')
-    st.write("Use the dropdown menu to view trends in the average bail amount set, number of monetary bail cases, and frequency of monetary bail set. Use the slider to change the number of days over which the moving average is calculated.")
+    st.write("Use the dropdown menu to view trends in the mean of different bail metrics. Use the slider to change the number of days over which the moving average is calculated.")
     st.write("Mean bail amount trended slightly upward over the course of the year. \
     Monetary bail case counts dropped in March, following a decrease in total arrests as a COVID-19 mitigation measure, but returned to pre-pandemic levels by October.\
     Monetary bail frequency held steady for much of the year, with a slight upward trend starting in September.")   

--- a/dashboard/aggregate.py
+++ b/dashboard/aggregate.py
@@ -17,15 +17,17 @@ def load_data():
 def app():
     st.title('Year-end Summary')
     st.write('This section provides a general year-end summary of bail in Philadelphia in 2020, including trends and aggregate-level information for case counts, bail types, and monetary bail set and posted.')
-    
-    # Get bail data
-    #df = preprocess()
-    df = load_data()
 
     # ----------------------------------------------------
     # Summary numbers 
-    # ----------------------------------------------------
-    #st.header('Year-end Summary')
+    # ----------------------------------------------------    
+    # Get bail data
+    #df = preprocess()
+    
+    st.subheader('Yearly totals')
+    st.write("Use the slider to change the range of dates over which the sum is calculated.")
+    
+    df = load_data()
     
     # Get range of dates and create slider to select date range (workaround since Streamlit doesn't have a date range slider)
     # Try.. except block is another workzround. Streamlit caching doesn't work with datetime module
@@ -160,9 +162,9 @@ def app():
     # ----------------------------------------------------
     st.subheader('Bail trends over the year')
     st.write("Use the dropdown menu to view trends in the average bail amount set, number of monetary bail cases, and frequency of monetary bail set. Use the slider to change the number of days over which the moving average is calculated.")
-    st.write("Mean bail amount trended upward over the course of the year. \
+    st.write("Mean bail amount trended slightly upward over the course of the year. \
     Monetary bail case counts dropped in March, following a decrease in total arrests as a COVID-19 mitigation measure, but returned to pre-pandemic levels by October.\
-    Monetary bail frequency held steady for much of the year, with an upward trend starting in September.")   
+    Monetary bail frequency held steady for much of the year, with a slight upward trend starting in September.")   
     # Make data for each metric + data to initialize the chart
     ma_dfs = {'Bail Amount': df.groupby('bail_date').mean()['bail_amount'], 
               'Monetary Bail Cases': df[df['bail_type'] == 'Monetary'].groupby('bail_date').size(),

--- a/dashboard/home.py
+++ b/dashboard/home.py
@@ -5,7 +5,7 @@ def app():
     st.image('figures/PBF_logo_edit.png', use_column_width = True)
 
     # What is this app
-    st.header('Bail in Philadelphia, 2020')
+    st.title('Bail in Philadelphia, 2020')
     st.write("This dashboard provides a summary of the bail situation in Philadelphia in 2020. \
         We provide a general year-end summary, along with breakdown by neighborhood, magistrate, and race.\
         Please use the navigation panel on the left to select a page.")    
@@ -16,7 +16,7 @@ def app():
     st.write("The Philadelphia Bail Fund is a revolving fund that posts bail for people who are indigent and cannot afford bail.\
         Our goal is to keep families and communities together and vigorously advocate for the end to cash bail in Philadelphia. ")
 
-    st.header("Get involved")
+    st.subheader("Get involved")
     # learn more
     pbf_link = 'Learn more at [phillybailfund.org](http://phillybailfund.org)'
     st.markdown(pbf_link, unsafe_allow_html = True)
@@ -27,3 +27,8 @@ def app():
 
     # contact us
     st.markdown('Contact us at <a href="mailto:info@phillybailfund.org">info@phillybailfund.org</a>', unsafe_allow_html=True)
+    
+    # What is Code for Philly
+    st.header('Code for Philly')
+    st.write("This dashboard was created by [Code for Philly](https://codeforphilly.org/), a Code For America brigade, in collaboration with the Philadelphia Bail Fund.\
+    We're part of a national alliance of community organizers, developers, and designers that are putting technology to work in service of our local communities.")

--- a/dashboard/neighborhood.py
+++ b/dashboard/neighborhood.py
@@ -47,7 +47,8 @@ def preprocess_acs():
 def app():
     st.title('Breakdown by Neighborhood')
     st.write('This section provides an interactive breakdown of case counts and amounts of bail set and paid by Philadelphia zip code, in tandem with income, poverty, and unemployment data from the American Community Survey (ACS), collected by the U.S. Census Bureau.')
-    st.write('Use the dropdown menus to select a given bail and census metric associated with each map. Zip codes with higher levels of each bail metric tend to have lower median incomes and higher poverty and unemployment rates.')
+    st.write('Use the dropdown menus to select a given bail and census metric associated with each map.')
+    st.write('Zip codes with the highest case loads and total bail amounts set and paid tend to have lower median incomes and higher poverty and unemployment rates.')
     st.markdown(f"""
     Source Data: [Median Income]({INCOME}), [Poverty Level]({POVERTY}), [Unemployment Rate]({UNEMPLOYMENT})
         """)
@@ -63,7 +64,7 @@ def app():
     bail_amounts = df.groupby('zipcode_clean').sum()[['bail_amount']].reset_index()
     bail_paid = df.groupby('zipcode_clean').sum()[['bail_paid']].reset_index()
     bail_paid_pct = df[df['bail_paid'] > 0].groupby('zipcode_clean').size().div(df['zipcode_clean'].value_counts()).mul(100).round(1).reset_index().rename(columns={'index':'zip', 0:'pct'})
-    cases_dfs = {'Case Count': case_counts, 'Bail Amount': bail_amounts, 'Bail Paid': bail_paid, 'Percent of Cases where Bail Paid': bail_paid_pct}
+    cases_dfs = {'Case Count': case_counts, 'Total Bail Set': bail_amounts, 'Total Bail Posted': bail_paid, 'Percent of Cases where Bail Paid': bail_paid_pct}
     
     # Geo data
     # Approximate Philly lat/long
@@ -76,7 +77,7 @@ def app():
     
     # Interactive map for bail metrics
     # Make dropdown for bail metric
-    metric = col1.selectbox('Bail Metric', ('Case Count', 'Bail Amount', 'Bail Paid', 'Percent of Cases where Bail Paid'))
+    metric = col1.selectbox('Bail Metric', ('Case Count', 'Total Bail Set', 'Total Bail Posted', 'Percent of Cases where Bail Paid'))
     
     # Get data for the selected metric
     data = cases_dfs[metric]

--- a/dashboard/neighborhood.py
+++ b/dashboard/neighborhood.py
@@ -46,25 +46,54 @@ def preprocess_acs():
 
 def app():
     st.title('Breakdown by Neighborhood')
-    st.write('This section provides an interactive breakdown of case counts and amounts of bail set and paid by Philadelphia zip code, in tandem with income, poverty, and unemployment data from the American Community Survey (ACS), collected by the U.S. Census Bureau.')
-    st.write('Use the dropdown menus to select a given bail and census metric associated with each map.')
-    st.write('Zip codes with the highest case loads and total bail amounts set and paid tend to have lower median incomes and higher poverty and unemployment rates.')
+    st.write('This section provides an interactive breakdown of case counts, total amounts of bail set and paid, and bail payment rate by Philadelphia zip code, in tandem with income, poverty, and unemployment data from the American Community Survey (ACS) collected by the U.S. Census Bureau.')
     st.markdown(f"""
     Source Data: [Median Income]({INCOME}), [Poverty Level]({POVERTY}), [Unemployment Rate]({UNEMPLOYMENT})
         """)
     
+    st.header('Interactive Maps')
+    st.write('Use the dropdown menus to select a given bail and census metric associated with each map.\
+    Hover over an area to view the corresponding metric value and zip code number.\
+    For bail metrics other than case counts, only zip codes with at least 100 cases are shown.')
+    st.write('Zip codes with the highest case counts, highest total bail amounts set and posted, and lowest bail posting rates tend to have lower median incomes and higher poverty and unemployment rates.')
+    st.write("**<font color='red'>Question for PBF</font>**: are there any other bail metrics you'd be interested in viewing in this map?", unsafe_allow_html=True)
+    
     col1, col2 = st.beta_columns(2)
     
-    # Get bail data
+    # ------------------------------------
+    # Process bail data
+    # ------------------------------------
     #df = preprocess()
     df = load_data()
 
     # Create data assoc. w/ each metric (over all bail types) and put in dict
-    case_counts = pd.DataFrame(df['zipcode_clean'].value_counts().reset_index().rename(columns={'index': 'zip', 'zipcode_clean': 'count'}))
+    case_counts = pd.DataFrame(df['zipcode_clean'].value_counts()
+                               .reset_index().rename(columns={'index': 'zip', 'zipcode_clean': 'count'}))
     bail_amounts = df.groupby('zipcode_clean').sum()[['bail_amount']].reset_index()
     bail_paid = df.groupby('zipcode_clean').sum()[['bail_paid']].reset_index()
-    bail_paid_pct = df[df['bail_paid'] > 0].groupby('zipcode_clean').size().div(df['zipcode_clean'].value_counts()).mul(100).round(1).reset_index().rename(columns={'index':'zip', 0:'pct'})
-    cases_dfs = {'Case Count': case_counts, 'Total Bail Set': bail_amounts, 'Total Bail Posted': bail_paid, 'Percent of Cases where Bail Paid': bail_paid_pct}
+    df_monetary = df[df['bail_type'] == 'Monetary'][['zipcode_clean', 'bail_paid']] 
+    bail_paid_pct = (df_monetary[df_monetary['bail_paid'] > 0]['zipcode_clean'].value_counts()
+                     .divide(df_monetary['zipcode_clean'].value_counts())
+                     .mul(100).round(1)
+                     .reset_index().rename(columns={'index': 'zip', 'zipcode_clean': 'pct'}))
+    #public_defender = (df[df['attorney_type'] == 'Public']['zipcode_clean'].value_counts()
+    #                 .divide(df['zipcode_clean'].value_counts())
+    #                 .mul(100).round(1)
+    #                 .reset_index().rename(columns={'index': 'zip', 'zipcode_clean': 'pct'}))
+        
+    # Select only zip codes with at least minCount cases to show in bail metrics map
+    minCount = 100
+    minZips = case_counts[case_counts['count'] >= minCount]['zip'].to_list()
+    #case_counts = case_counts[case_counts['zip'].isin(minZips)]
+    bail_amounts = bail_amounts[bail_amounts['zipcode_clean'].isin(minZips)]
+    bail_paid = bail_paid[bail_paid['zipcode_clean'].isin(minZips)]
+    bail_paid_pct = bail_paid_pct[bail_paid_pct['zip'].isin(minZips)]
+    #public_defender = public_defender[public_defender['zip'].isin(minZips)]
+    
+    cases_dfs = {'Case Count': case_counts,
+                 'Total Bail Set ($)': bail_amounts,
+                 'Total Bail Posted ($)': bail_paid,
+                 'Bail Posting Rate': bail_paid_pct}
     
     # Geo data
     # Approximate Philly lat/long
@@ -75,9 +104,11 @@ def app():
     with open(zips_geo) as f:
         zips_data = json.load(f)
     
+    # ------------------------------------
     # Interactive map for bail metrics
+    # ------------------------------------
     # Make dropdown for bail metric
-    metric = col1.selectbox('Bail Metric', ('Case Count', 'Total Bail Set', 'Total Bail Posted', 'Percent of Cases where Bail Paid'))
+    metric = col1.selectbox('Bail Metric', (tuple(cases_dfs.keys())))
     
     # Get data for the selected metric
     data = cases_dfs[metric]

--- a/dashboard/race_gender.py
+++ b/dashboard/race_gender.py
@@ -14,18 +14,22 @@ def app():
     st.header("Year-end Summary")
 
     st.image(Image.open('figures/race_aggregate_frequency.png'), width=500)      
-    st.write("In the following analysis, we consider only defendants who have been labeled as White or Black due to sample size concerns.")
+    st.write("In the following analysis, only defendants who have been labeled as White or Black are considered, due to sample size concerns.\
+    Note: the Philadelphia Bail Fund has observed that the Philadelphia court system appears to record most non-Black and non-Asian people, such as Latinx and Indigenous people, as White.\
+    Thus, while the label \"White\" is maintained in the charts, this group is referred to as \"non-Black\" in the text.")
+    st.write("**<font color='red'>Question for PBF</font>**: what disclaimer language would you like to include here? The above was informed by the language in the July 2020 report.", unsafe_allow_html=True)
+    st.write("Given the low freqency of nonmonetary and nominal bail (<1% of all cases), cases where these bail types were set are excluded from consideration in this section, for ease of interpretation.")
     
     st.subheader("Bail type frequency")
+    st.write("Relative to non-Black defendants, Black defendants had monetary bail set more frequently, ROR bail set less frequently, and were more frequently denied bail.")
     st.image(Image.open('figures/race_aggregate_type.png'), width=int(1.5*imgWidth))
-    st.write("Compared to White defendants, Black defendants were less frequently granted ROR bail, which has no monetary payment stipulation, and were more frequently denied bail.")
 
     st.subheader("Bail amount frequency")
-    st.write("When monetary bail is set, White defendants were more frequently assigned a bail amount between $10,000 and $25,000, and Black defendants were more frequently assigned a bail amount between $100,000 and $500,000.")
+    st.write("When monetary bail was set, non-Black defendants were more frequently assigned a bail amount between $10,000 and $25,000, and Black defendants were more frequently assigned a bail amount between $100,000 and $500,000.")
     st.image(Image.open('figures/race_aggregate_set.png'), width=imgWidth)
     
     st.subheader("Bail posted frequency")
-    st.write("Overall, slightly over half of White and Black defendants posted bail (52.5% and 50.6% respsectively). White and Black defendants posted bail at similar rates for each range of bail amounts set.")    
+    st.write("Overall, slightly over half of Black and non-Black defendants posted bail (50.6% and 52.5% respsectively), and defendants posted bail at similar rates for each range of bail amounts set, independent of race. The largest difference was for bail set below $1000, for which Black defendants posted bail at around half the rate of non-Black defendants.")    
     st.image(Image.open('figures/race_aggregate_bailPosted.png'), width=imgWidth)
     """
     st.image(Image.open('figures/bail_paid_race.png'), width=imgWidth)
@@ -47,10 +51,10 @@ def app():
     st.write(
     """While the above figures provide a useful year-end summary, they include variation in bail types and amounts that may be attributed to factors other than race, such as offense types. 
     
-To control for offense types, we conducted a matched study where we sampled cases with identical lists of charges from cases with White and Black defendants. The following results were obtained from the 10593 cases (5115 for Black defendants, 5112 for White defendants) that were sampled. """
+To control for offense types, we conducted a matched study where we sampled cases with identical lists of charges from cases with Black and non-Black defendants. The following results were obtained from the 10593 cases (5115 for Black defendants, 5112 for White defendants) that were sampled.
+
+In this matched sample, bail types and amounts were set at similar rates for Black and non-Black defendants, indicating that variations in these metrics between cases with the same charged offenses may be largely attributed to factors other than the defendant's race (such as the magistrate assigned to the case). """
     )
         
     st.image(Image.open('figures/race_matched_type.png'), width=int(1.5*imgWidth))    
     st.image(Image.open('figures/race_matched_set.png'), width=imgWidth)    
-
-    st.write("When comparing matched cases, there was no difference between bail types or bail amounts set for Black and White defendants.")


### PR DESCRIPTION
- Ask a handful of questions for PBF, marked in red
- Home page: add short blurb on Code for Philly
- Summary page: Add more detail on specific bail amounts set and paid (likely too much detail for final dashboard, but maybe of interest to PBF)
- Neighborhood page:
    - Update calculation of bail posted frequency to match that of other analyses
    - Add case count floor for display of bail metrics (currently set at 100) so that the bail posted frequency metric is more meaningful
- Race page: Add disclaimer language

Note that the pie charts in the Summary page are still tied to the slider! Not sure that is desired behavior with the rearrangement.