### PR TITLE
Update figures, formatting, and text

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import by_numbers
 import magistrate
 import price
 import neighborhood
-import race_gender
 import by_demographics
 import interesting_finds
 
@@ -14,11 +13,9 @@ def main():
     PAGES = {
         "By Year" : by_numbers,
         "By Actor" : magistrate,
-        "By Price" : price,
-        "By Neighborhood" : neighborhood,
-        "By Demographics (original)": race_gender,
         "By Demographics": by_demographics,
-        "About PBF": home,
+        "By Cost to Philadelphians" : neighborhood,
+        "About": home,
     }
     st.sidebar.title('Navigation')
     selection = st.sidebar.radio("Please select a page", list(PAGES.keys()))

--- a/by_demographics.py
+++ b/by_demographics.py
@@ -85,10 +85,46 @@ def app():
     arr_age_pct_2021 = np.array([df_age_bail_type[2021][age] for age in age_groups], dtype=object)    
     arr_age_count_2020 = np.array([df_age_bail_type_count[2020][age] for age in age_groups], dtype=object)
     arr_age_count_2021 = np.array([df_age_bail_type_count[2021][age] for age in age_groups], dtype=object)
+
+    # ----------------------------------
+    #  Interactive figure formatting
+    # ----------------------------------
+    
+    dropdown_content = dict(active=0,
+                            x=-0.35,
+                            y=0.9,
+                            xanchor='left',
+                            yanchor='top',
+                            buttons=list([
+                                dict(label="2020",
+                                     method="update",
+                                     args=[{"visible": [True, True, True, True, True,
+                                                        False, False, False, False, False]}]),
+                                dict(label="2021",
+                                     method="update",
+                                     args=[{"visible": [False, False, False, False, False,
+                                                        True, True, True, True, True]}])
+                                ])
+                           )
+    
+    dropdown_title = dict(text="Select year:",
+                          x=-0.35, 
+                          y=0.98,
+                          xref="paper",
+                          yref="paper",
+                          align="left",
+                          showarrow=False)
+    
+    common_layout = dict(barmode='stack',
+                         legend={'traceorder': 'normal'},
+                         legend_title="Bail Types",
+                         yaxis_title="Percent")
     
     # ----------------------------------
     #  Interactive figure: Bail Type Percentages by Race
     # ----------------------------------
+    st.write("In 2020, monetary bail was set more frequently for people identified by the court system as Black than those identified as non-Black (White or Other).")    
+    
     fig = go.Figure()
     
     for j, bailType in enumerate(bail_types):
@@ -122,54 +158,26 @@ def app():
                 visible=False
         ))
 
-    fig.update_layout(
-        barmode='stack',
-        legend={'traceorder': 'normal'},
-        legend_title="Bail Types",
-        title="Breakdown of Bail Types Set, by Race",
-        xaxis_title="Race",
-        yaxis_title="Percent",
-        xaxis_tickvals=list(range(len(races))),
-        xaxis_ticktext=races
-    )
+    fig.update_layout(title="Breakdown of Bail Type by Race",
+                      xaxis_title="Race",
+                      xaxis_tickvals=list(range(len(races))),
+                      xaxis_ticktext=races)
     
-    fig.update_layout(
-        updatemenus=[
-            dict(active=0,
-                 x=-0.35,
-                 xanchor='left',
-                 y=0.9,
-                 yanchor='top',
-                 buttons=list([
-                     dict(label="2020",
-                          method="update",
-                          args=[{"visible": [True, True, True, True, True, False, False, False, False, False]},
-                                {"title": "Bail type by race in 2020"}]),
-                     dict(label="2021",
-                          method="update",
-                          args=[{"visible": [False, False, False, False, False, True, True, True, True, True]},
-                                {"title": "Bail type by race in 2021"}])
-                               ])
-                     )
-                ])
-    
-    fig.update_layout(
-        annotations=[
-            dict(text="Select year", x=-0.35, xref="paper", y=0.98, yref="paper",
-                                 align="left", showarrow=False)
-        ])
+    fig.update_layout(updatemenus=[dropdown_content],
+                      annotations=[dropdown_title],
+                      **common_layout)
     
     f_pct = go.FigureWidget(fig)
     st.plotly_chart(f_pct)    
 
-    st.write("In 2020, monetary bail was set more frequently for people identified by the court system as Black than those identified as non-Black (White or Other).")    
-    
     st.write("Note: While additional race categories beyond \"White\" and \"Black\" are recognized by the Pennsylvania court system, these are grouped together as \"Other\" out of anonymization concerns. The Philadelphia Bail Fund has observed that the Philadelphia court system appears to record most non-Black and non-Asian people, such as Latinx and Indigenous people, as White.")
     st.write("**<font color='red'>Question for PBF</font>**: what disclaimer language would you like to include here? The above was informed by the language in the July 2020 report.", unsafe_allow_html=True)    
     
     # ----------------------------------
     #  Interactive figure: Bail Type Percentages by Sex
     # ----------------------------------    
+    st.write("In 2020, monetary bail was set more frequently for people identified by the court system as male than those identified as female.")
+    
     fig = go.Figure()
     
     for j, bailType in enumerate(bail_types):
@@ -203,51 +211,25 @@ def app():
                 visible=False
         ))
 
-    fig.update_layout(
-        barmode='stack',
-        legend={'traceorder': 'normal'},
-        legend_title="Bail Types",
-        title="Breakdown of Bail Types Set, by Sex",
-        xaxis_title="Sex",
-        yaxis_title="Percent",
-        xaxis_tickvals=list(range(len(sexes))),
-        xaxis_ticktext=sexes
-    )
+    fig.update_layout(title="Breakdown of Bail Type by Sex",
+                      xaxis_title="Sex",
+                      xaxis_tickvals=list(range(len(sexes))),
+                      xaxis_ticktext=sexes)
     
-    fig.update_layout(
-        updatemenus=[
-            dict(active=0,
-                 x=-0.35,
-                 xanchor='left',
-                 y=0.9,
-                 yanchor='top',
-                 buttons=list([
-                     dict(label="2020",
-                          method="update",
-                          args=[{"visible": [True, True, True, True, True, False, False, False, False, False]},
-                                {"title": "Bail type by sex in 2020"}]),
-                     dict(label="2021",
-                          method="update",
-                          args=[{"visible": [False, False, False, False, False, True, True, True, True, True]},
-                                {"title": "Bail type by sex in 2021"}])
-                               ])
-                     )
-                ])
-    
-    fig.update_layout(
-        annotations=[
-            dict(text="Select year", x=-0.35, xref="paper", y=0.98, yref="paper",
-                                 align="left", showarrow=False)
-        ])
+    fig.update_layout(updatemenus=[dropdown_content],
+                      annotations=[dropdown_title],
+                      **common_layout)
 
     f_pct_sex = go.FigureWidget(fig)
     st.plotly_chart(f_pct_sex)    
 
-    st.write("In 2020, monetary bail was set more frequently for people identified by the court system as male than those identified as female.")
+
     
     # ----------------------------------
     #  Interactive figure: Bail Type Percentages by Age
     # ----------------------------------    
+    st.write("In 2020, the frequency of monetary bail decreased with increasing age group.")
+    
     fig = go.Figure()
     
     for j, bailType in enumerate(bail_types):
@@ -281,44 +263,16 @@ def app():
                 visible=False
         ))
 
-    fig.update_layout(
-        barmode='stack',
-        legend={'traceorder': 'normal'},
-        legend_title="Bail Types",
-        title="Breakdown of Bail Types Set, by Age",
-        xaxis_title="Age Group",
-        yaxis_title="Percent",
-        xaxis_tickvals=list(range(len(age_groups))),
-        xaxis_ticktext=age_groups
-    )
+    fig.update_layout(title="Breakdown of Bail Type by Age",
+                      xaxis_title="Age Group",
+                      xaxis_tickvals=list(range(len(age_groups))),
+                      xaxis_ticktext=age_groups)
     
-    fig.update_layout(
-        updatemenus=[
-            dict(active=0,
-                 x=-0.35,
-                 xanchor='left',
-                 y=0.9,
-                 yanchor='top',
-                 buttons=list([
-                     dict(label="2020",
-                          method="update",
-                          args=[{"visible": [True, True, True, True, True, False, False, False, False, False]},
-                                {"title": "Bail type by age in 2020"}]),
-                     dict(label="2021",
-                          method="update",
-                          args=[{"visible": [False, False, False, False, False, True, True, True, True, True]},
-                                {"title": "Bail type by age in 2021"}])
-                               ])
-                     )
-                ])
-    
-    fig.update_layout(
-        annotations=[
-            dict(text="Select year", x=-0.35, xref="paper", y=0.98, yref="paper",
-                                 align="left", showarrow=False)
-        ])
+    fig.update_layout(updatemenus=[dropdown_content],
+                      annotations=[dropdown_title],
+                      **common_layout)
 
     f_pct_age = go.FigureWidget(fig)
     st.plotly_chart(f_pct_age)   
     
-    st.write("In 2020, the frequency of monetary bail being set decreased with increasing age group.") 
+ 

--- a/by_demographics.py
+++ b/by_demographics.py
@@ -58,6 +58,8 @@ def app():
     # ----------------------------------    
     st.title('Breakdown by Demographics')
     
+    st.write("How has bail set differed between **races, genders, and age groups**?")   
+    
     # ----------------------------------
     #  Preprocessing
     # ----------------------------------
@@ -91,8 +93,8 @@ def app():
     # ----------------------------------
     
     dropdown_content = dict(active=0,
-                            x=-0.35,
-                            y=0.9,
+                            x=-0.25,
+                            y=0.92,
                             xanchor='left',
                             yanchor='top',
                             buttons=list([
@@ -108,14 +110,15 @@ def app():
                            )
     
     dropdown_title = dict(text="Select year:",
-                          x=-0.35, 
-                          y=0.98,
+                          x=-0.25, 
+                          y=1,
                           xref="paper",
                           yref="paper",
                           align="left",
                           showarrow=False)
     
-    common_layout = dict(barmode='stack',
+    common_layout = dict(margin={'t':25},
+                         barmode='stack',
                          legend={'traceorder': 'normal'},
                          legend_title="Bail Types",
                          yaxis_title="Percent")
@@ -123,6 +126,7 @@ def app():
     # ----------------------------------
     #  Interactive figure: Bail Type Percentages by Race
     # ----------------------------------
+    st.subheader('Race')
     st.write("In 2020, monetary bail was set more frequently for people identified by the court system as Black than those identified as non-Black (White or Other).")    
     
     fig = go.Figure()
@@ -158,8 +162,7 @@ def app():
                 visible=False
         ))
 
-    fig.update_layout(title="Breakdown of Bail Type by Race",
-                      xaxis_title="Race",
+    fig.update_layout(xaxis_title="Race",
                       xaxis_tickvals=list(range(len(races))),
                       xaxis_ticktext=races)
     
@@ -170,12 +173,12 @@ def app():
     f_pct = go.FigureWidget(fig)
     st.plotly_chart(f_pct)    
 
-    st.write("Note: While additional race categories beyond \"White\" and \"Black\" are recognized by the Pennsylvania court system, these are grouped together as \"Other\" out of anonymization concerns. The Philadelphia Bail Fund has observed that the Philadelphia court system appears to record most non-Black and non-Asian people, such as Latinx and Indigenous people, as White.")
-    st.write("**<font color='red'>Question for PBF</font>**: what disclaimer language would you like to include here? The above was informed by the language in the July 2020 report.", unsafe_allow_html=True)    
+    st.write("*Note*: While additional race categories beyond \"White\" and \"Black\" are recognized by the Pennsylvania court system, these are grouped together as \"Other\" out of anonymization concerns. The Philadelphia Bail Fund has observed that the Philadelphia court system appears to record most non-Black and non-Asian people, such as Latinx and Indigenous people, as White.")
     
     # ----------------------------------
     #  Interactive figure: Bail Type Percentages by Sex
     # ----------------------------------    
+    st.subheader('Sex')
     st.write("In 2020, monetary bail was set more frequently for people identified by the court system as male than those identified as female.")
     
     fig = go.Figure()
@@ -211,8 +214,7 @@ def app():
                 visible=False
         ))
 
-    fig.update_layout(title="Breakdown of Bail Type by Sex",
-                      xaxis_title="Sex",
+    fig.update_layout(xaxis_title="Sex",
                       xaxis_tickvals=list(range(len(sexes))),
                       xaxis_ticktext=sexes)
     
@@ -227,7 +229,8 @@ def app():
     
     # ----------------------------------
     #  Interactive figure: Bail Type Percentages by Age
-    # ----------------------------------    
+    # ----------------------------------
+    st.subheader('Age')
     st.write("In 2020, the frequency of monetary bail decreased with increasing age group.")
     
     fig = go.Figure()
@@ -263,8 +266,7 @@ def app():
                 visible=False
         ))
 
-    fig.update_layout(title="Breakdown of Bail Type by Age",
-                      xaxis_title="Age Group",
+    fig.update_layout(xaxis_title="Age Group",
                       xaxis_tickvals=list(range(len(age_groups))),
                       xaxis_ticktext=age_groups)
     

--- a/by_numbers.py
+++ b/by_numbers.py
@@ -41,8 +41,9 @@ def app():
 - **ROR** (“released on own recognizance”), where a defendant must agree to show up to all future court proceedings,
 - **unsecured**, where the defendant is liable for a set bail amount if they do not show up to future court proceedings,
 - a **nonmonetary** bail condition, or
-- the defendant may be **denied** bail.""")
-    st.write("Monetary bail is the most frequently set bail type.")        
+- the defendant may be **denied** bail.""")    
+    
+    st.write("Monetary bail is the most frequently set bail type.")  
     
     # ----------------------------------
     #  Preprocessing
@@ -51,11 +52,17 @@ def app():
     years = [2020, 2021]
     df_month, df_by_numbers = load_data()
     df_year = df_month.groupby(['bail_year', 'bail_type'])['count'].sum()
+    df_monetary = df_month[df_month['bail_type'] == 'Monetary']
+    
     # TODO: update so that df is sorted according to bail_types, to match bail type colors/orders accross pages! Currently, bail_types must be set to match the groupby order by hand.
 
     arr_year_total = np.array([df_year[val] for val in years])
     yearly_sums = [df_year[x].sum() for x in years]
     arr_year_pct = np.array([100*df_year[val]/yearly_sums[i] for i, val in enumerate(years)])
+    gb_month = df_month.groupby(['bail_year', 'bail_month'])['count'].sum()
+    df_monetary['pct'] = df_monetary.apply(lambda row:
+                                           100*row['count']/gb_month[row['bail_year']][row['bail_month']],
+                                           axis=1)
     
     # ----------------------------------
     #  Interactive figure: Bail Type Percentages
@@ -65,9 +72,9 @@ def app():
     for j, bailType in enumerate(bail_types):
         bail_pct = arr_year_pct[:, j]
         fig.add_trace(go.Bar(
-                x=[0,1],
-                y=bail_pct,
-                orientation="v",
+                y=[0,1],
+                x=bail_pct,
+                orientation="h",
                 text="",
                 textposition="inside",
                 name=bailType,
@@ -80,16 +87,18 @@ def app():
         barmode='stack',
         legend={'traceorder': 'normal'},
         legend_title="Bail Types",
-        title="Breakdown of Bail Types Set: Percentages",
-        xaxis_title="Year",
-        yaxis_title="Percent",
-        xaxis_tickvals=[0, 1],
-        xaxis_ticktext=["2020","2021 YTD"]
+        title="Breakdown of bail types set",
+        yaxis_title="Year",
+        xaxis_title="Percentage of cases",
+        yaxis_tickvals=[0, 1],
+        yaxis_ticktext=["2020","2021 YTD"]
     )
-
+    
     f_pct = go.FigureWidget(fig)
     st.plotly_chart(f_pct)    
     
+  
+    '''
     # ----------------------------------
     #  Interactive figure: Bail Type Totals
     # ----------------------------------     
@@ -123,13 +132,98 @@ def app():
 
     f_total = go.FigureWidget(fig)
     st.plotly_chart(f_total)
+    '''
+
+    # ----------------------------------
+    #  Interactive figure: monetary bail totals
+    # ----------------------------------     
+
+    st.subheader("Monetary Bail")
+    
+    st.write("""So far in 2021, the percentage of cases each month for which monetary bail is set is slightly higher than for the same month in 2020.""")
+
+    months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    
+    fig = go.Figure()
+
+    # As percentage of total cases
+    for i, year in enumerate(years):
+        month_data = df_monetary[df_monetary['bail_year'] == year]['pct']
+        fig.add_trace(go.Bar(
+            y=month_data,
+            name=year,
+            hoverinfo="text",
+            hovertext=[f"{m} {year}: {bailPct:.1f}% of cases"
+                       for m, bailPct in zip(months, month_data)],
+            visible = True
+            ))         
+    
+    # As total counts
+    for i, year in enumerate(years):
+        month_data = df_monetary[df_monetary['bail_year'] == year]['count']
+        fig.add_trace(go.Bar(
+            y=month_data,
+            name=year,
+            hoverinfo="text",
+            hovertext=[f"{m} {year}: {bailCount:,d} people"
+                       for m, bailCount in zip(months, month_data)],
+            visible=False
+            ))   
+    
+    # Layout
+    fig.update_layout(
+        title="Monetary bail cases per month",
+        legend_title="Year",
+        xaxis_title="Month",
+        xaxis_tickvals=list(range(12)),
+        xaxis_ticktext=months
+    )
+    
+    fig.update_layout(
+        annotations=[
+            dict(text="Select data to view:",
+                 x=-0.5,
+                 y=1.08,
+                 xref="paper",
+                 yref="paper",
+                 align="left",
+                 showarrow=False
+                )
+        ]
+    )
+    
+    fig.update_layout(
+        updatemenus=[dict(
+            active=0,
+            x=-0.5,
+            y=1,
+            xanchor='left',
+            yanchor='top',
+            buttons=list([
+                dict(label="Percentage of cases",
+                     method="update",
+                     args=[{"visible": [True, True, False, False]},
+                           {'yaxis': {'title': 'Percentage of cases'}}
+                          ]
+                    ),
+                dict(label="Number of people",
+                     method="update",
+                     args=[{"visible": [False, False, True, True]},
+                           {'yaxis': {'title': 'Number of people'}}
+                          ]
+                    )                        
+                ]),
+            )]
+        )
+    
+    f_total = go.FigureWidget(fig)
+    st.plotly_chart(f_total)    
     
     # ----------------------------------
     #  Summary table
     # ----------------------------------  
 
-    st.subheader("Monetary Bail")
-    st.write("""In 2020 cases where monetary bail was set, bail was posted in only 44% of cases, meaning that **a majority of people were not able to pay the amount required to be released from jail**.""")
+    st.write("""In 2020 and 2021, the median payment of $0 means that over half of people did not post bail: **a majority of people have not been able to pay the amount required to be released from jail**.""") #bail was posted in only 44% of monetary bail cases
     
     st.table(df_by_numbers)
     

--- a/by_numbers.py
+++ b/by_numbers.py
@@ -34,16 +34,16 @@ def app():
     # ----------------------------------    
     st.title('Breakdown by Year')
 
-    st.subheader("Bail Types")
+    st.subheader('How have bail types set in 2021 compared to those set in 2020?')
     
     st.write("""During a defendant's arraignment (a hearing held shortly after they are arrested), one of several [types of bail](https://www.pacodeandbulletin.gov/Display/pacode?file=/secure/pacode/data/234/chapter5/s524.html) may be set:
 - **monetary**, where a bail amount is set and the defendant is held in jail until a portion (typically 10%) is paid (\"posted\"),
-- **ROR** (“released on own recognizance”), where a defendant must agree to show up to all future court proceedings,
+- **ROR** (“released on own recognizance”), where the defendant must agree to show up to all future court proceedings,
 - **unsecured**, where the defendant is liable for a set bail amount if they do not show up to future court proceedings,
 - a **nonmonetary** bail condition, or
 - the defendant may be **denied** bail.""")    
     
-    st.write("Monetary bail is the most frequently set bail type.")  
+    st.write("In 2020 and so far in 2021, **monetary bail has been the most frequently set bail type**.")  
     
     # ----------------------------------
     #  Preprocessing
@@ -65,10 +65,11 @@ def app():
                                            axis=1)
     
     # ----------------------------------
-    #  Interactive figure: Bail Type Percentages
+    #  Interactive figure: bail type percentages/counts, yearly comparison
     # ----------------------------------
     fig = go.Figure()
     
+    # Plot percentages
     for j, bailType in enumerate(bail_types):
         bail_pct = arr_year_pct[:, j]
         fig.add_trace(go.Bar(
@@ -84,6 +85,7 @@ def app():
                 visible=True
         ))
 
+    # Plot counts
     for j, bailType in enumerate(bail_types):
         bail_total = arr_year_total[:,j]
         fig.add_trace(go.Bar(
@@ -99,22 +101,36 @@ def app():
                 visible=False
         ))             
 
+    # Formatting
     fig.update_layout(
+        margin={'t':25},
         barmode='stack',
         legend={'traceorder': 'normal'},
         legend_title="Bail Types",
-        title="Breakdown of bail types set",
         yaxis_title="Percentage of cases",
         xaxis_title="Year",
         xaxis_tickvals=[0, 1],
         xaxis_ticktext=["2020, total","2021, YTD"]
     )        
-        
+
+    fig.update_layout(
+        annotations=[
+            dict(text="Select data to view:",
+                 x=-0.6,
+                 y=1.00,
+                 xref="paper",
+                 yref="paper",
+                 align="left",
+                 showarrow=False
+                )
+        ]
+    )    
+    
     fig.update_layout(
         updatemenus=[dict(
             active=0,
-            x=-0.5,
-            y=1,
+            x=-0.6,
+            y=0.92,
             xanchor='left',
             yanchor='top',
             buttons=list([
@@ -140,49 +156,12 @@ def app():
     
     f_pct = go.FigureWidget(fig)
     st.plotly_chart(f_pct)    
-    
-  
-    '''
-    # ----------------------------------
-    #  Interactive figure: Bail Type Totals
-    # ----------------------------------     
-    
-    fig = go.Figure()
-
-    for j, bailType in enumerate(bail_types):
-        bail_total = arr_year_total[:,j]
-        fig.add_trace(go.Bar(
-                x=[0,1],
-                y=bail_total,
-                orientation="v",
-                text="",
-                textposition="inside",
-                name=bailType,
-                hoverinfo="text",
-                hovertext=[f"{bailType}: {bailCount:,d} people in {year}"
-                           for bailCount, year in zip(bail_total, years)]
-        ))             
-
-    fig.update_layout(
-        barmode='stack',
-        legend={'traceorder': 'normal'},
-        legend_title="Bail Types",
-        title="Breakdown of Bail Types Set: Totals",
-        xaxis_title="Year",
-        yaxis_title="Number of People",
-        xaxis_tickvals=[0, 1],
-        xaxis_ticktext=["2020","2021 YTD"]
-    )
-
-    f_total = go.FigureWidget(fig)
-    st.plotly_chart(f_total)
-    '''
 
     # ----------------------------------
-    #  Interactive figure: monetary bail totals
+    #  Interactive figure: monetary bail percentages/counts, monthly comparison
     # ----------------------------------     
 
-    st.subheader("Monetary Bail")
+    st.subheader('Monetary bail cases over time')
     
     st.write("""So far in 2021, the percentage of cases each month for which monetary bail is set is slightly higher than for the same month in 2020.""")
 
@@ -216,8 +195,10 @@ def app():
     
     # Layout
     fig.update_layout(
-        title="Monetary bail cases per month",
+        margin={'t':25},
+        #title="Monetary bail cases per month",
         legend_title="Year",
+        yaxis_title="Percentage of cases",
         xaxis_title="Month",
         xaxis_tickvals=list(range(12)),
         xaxis_ticktext=months
@@ -226,8 +207,8 @@ def app():
     fig.update_layout(
         annotations=[
             dict(text="Select data to view:",
-                 x=-0.5,
-                 y=1.08,
+                 x=-0.6,
+                 y=1.00,
                  xref="paper",
                  yref="paper",
                  align="left",
@@ -239,8 +220,8 @@ def app():
     fig.update_layout(
         updatemenus=[dict(
             active=0,
-            x=-0.5,
-            y=1,
+            x=-0.6,
+            y=0.92,
             xanchor='left',
             yanchor='top',
             buttons=list([

--- a/by_numbers.py
+++ b/by_numbers.py
@@ -72,27 +72,71 @@ def app():
     for j, bailType in enumerate(bail_types):
         bail_pct = arr_year_pct[:, j]
         fig.add_trace(go.Bar(
-                y=[0,1],
-                x=bail_pct,
-                orientation="h",
+                x=[0,1],
+                y=bail_pct,
+                orientation="v",
                 text="",
                 textposition="inside",
                 name=bailType,
                 hoverinfo="text",
                 hovertext=[f"{bailType}: {bailPct:.1f}% of {year} total"
-                           for bailPct, year in zip(bail_pct, years)]
+                           for bailPct, year in zip(bail_pct, years)],
+                visible=True
         ))
+
+    for j, bailType in enumerate(bail_types):
+        bail_total = arr_year_total[:,j]
+        fig.add_trace(go.Bar(
+                x=[0,1],
+                y=bail_total,
+                orientation="v",
+                text="",
+                textposition="inside",
+                name=bailType,
+                hoverinfo="text",
+                hovertext=[f"{bailType}: {bailCount:,d} people in {year}"
+                           for bailCount, year in zip(bail_total, years)],
+                visible=False
+        ))             
 
     fig.update_layout(
         barmode='stack',
         legend={'traceorder': 'normal'},
         legend_title="Bail Types",
         title="Breakdown of bail types set",
-        yaxis_title="Year",
-        xaxis_title="Percentage of cases",
-        yaxis_tickvals=[0, 1],
-        yaxis_ticktext=["2020","2021 YTD"]
-    )
+        yaxis_title="Percentage of cases",
+        xaxis_title="Year",
+        xaxis_tickvals=[0, 1],
+        xaxis_ticktext=["2020, total","2021, YTD"]
+    )        
+        
+    fig.update_layout(
+        updatemenus=[dict(
+            active=0,
+            x=-0.5,
+            y=1,
+            xanchor='left',
+            yanchor='top',
+            buttons=list([
+                dict(label="Percentage of cases",
+                     method="update",
+                     args=[{"visible": [True, True, True, True, True,
+                                        False, False, False, False, False]},
+                           {'yaxis': {'title': 'Percentage of cases'}}
+                          ]
+                    ),
+                dict(label="Number of people",
+                     method="update",
+                     args=[{"visible": [False, False, False, False, False,
+                                        True, True, True, True, True]},
+                           {'yaxis': {'title': 'Number of people'}}
+                          ]
+                    )                        
+                ]),
+            )]
+        )        
+        
+
     
     f_pct = go.FigureWidget(fig)
     st.plotly_chart(f_pct)    
@@ -155,7 +199,7 @@ def app():
             hoverinfo="text",
             hovertext=[f"{m} {year}: {bailPct:.1f}% of cases"
                        for m, bailPct in zip(months, month_data)],
-            visible = True
+            visible=True
             ))         
     
     # As total counts

--- a/home.py
+++ b/home.py
@@ -24,10 +24,10 @@ def app():
     # What is this app
     st.title('Bail in Philadelphia')
     st.write("""This dashboard provides a summary of the bail situation in Philadelphia **from January 2020 through March 2021**. A summary of how people in Philadelphia have been impacted by **monetary bail** is displayed at the top of each page. You can also explore how bail breaks down...
-- ...by year: how have **bail types and bail amounts set** in 2021 compared to those set in 2020?
-- ...by actor: how has bail depended on the magistrate or other **person setting bail**?
-- ...by price: how much bail have Philadelphians across the city **paid**? 
-- ...by demographics: how has bail differed between **races, genders, and age groups**?
+- by year: how have **bail types and bail amounts set** in 2021 compared to those set in 2020?
+- by actor: how has bail depended on the magistrate or other **person setting bail**?
+- by cost to people: how much bail have Philadelphians across the city **paid**? 
+- by demographics: how has bail differed between **races, genders, and age groups**?
 
 Use the navigation panel on the left to explore.""")    
     st.write(f"Information from the **{n_cases:,d} cases** used to create this dashboard was gathered from [Philadelphia Municipal Court docket sheets.](https://ujsportal.pacourts.us/DocketSheets/MC.aspx#)")

--- a/neighborhood.py
+++ b/neighborhood.py
@@ -44,15 +44,162 @@ def preprocess_acs():
     
     return acs_df
 
+@st.cache()
+def load_data_paid():
+    df_month = pd.read_csv('data/cleaned/app_bail_paid.csv')
+    return df_month
+
+
 def app():
-    # year-end summary
+    # ----------------------------------
+    #  Year-end summary (included on every page)
+    # ----------------------------------
     fig = plot_year_summary()
     f_year = go.FigureWidget(fig)
     st.plotly_chart(f_year)
 
-    minCount = 10 #100
+    # ----------------------------------
+    #  Introduction
+    # ----------------------------------    
     
-    st.title('Breakdown by Neighborhood')
+    st.title('Total price paid by Philadelphians')
+    
+    st.write("""When monetary bail is set, a defendent is detained in jail while awaiting trial unless they pay a portion (typically 10%) of the bail amount set.
+Depending on how much bail was set, the amount that a defendant must pay can be thousands of dollars. 
+This can be financially difficult for many Philadelphia families. """) 
+
+    # ----------------------------------
+    #  Interactive figure: Total price paid
+    # ----------------------------------       
+    
+    st.subheader('How much have Philadelphians paid in bail?')
+
+    st.write("In 2020, Philadelphians paid **tens of millions of dollars** in bail to be released from jail while they await their trials.")
+    
+    minCount = 10 #100
+
+    # prepare data
+    df_month = load_data_paid()
+    month_data = df_month['bail_paid']
+
+    df_year = df_month.groupby(['bail_year'])['bail_paid'].sum()
+    bail_paid_2020 = df_year[2020]
+    bail_paid_2021 = df_year[2021]
+
+    months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+    
+    # Plot figure
+    fig = go.Figure()
+
+    ### Add traces for yearly summary
+    # 2020
+    fig.add_trace(go.Bar(
+    x = [0],
+    y = [bail_paid_2020],
+    orientation = "v",
+    text = ["$"+f'{bail_paid_2020:,.0f}'],
+    textposition = "inside",
+    hoverinfo = "text",
+    hovertext = ["2020 <br>$"+f'{bail_paid_2020:,.0f}'],
+    showlegend = False
+    ))
+
+    # 2021
+    fig.add_trace(go.Bar(
+        x = [1],
+        y = [bail_paid_2021],
+        orientation = "v",
+        text = ["$"+f'{bail_paid_2021:,.0f}'],
+        textposition = "inside",
+        hoverinfo = "text",
+        hovertext = ["2021 <br>$"+f'{bail_paid_2021:,.0f}'],
+        showlegend = False
+
+        ))
+
+    ### add traces for monthly summary
+    # 2020 data
+    hovertext_2020 = [m + " 2020 <br>" + "$"+f'{v:,.0f}'  
+                    for (m,v) in zip(months, month_data[:12])]
+    fig.add_trace(go.Bar(
+        y = month_data[:12],
+        name = "2020",
+        hoverinfo = "text",
+        hovertext = hovertext_2020,
+        visible = False
+        ))
+
+    # 2021 data
+    hovertext_2021 = [m + " 2021 <br>" + "$"+f'{v:,.0f}'
+                    for (m,v) in zip(months,month_data[12:])]
+    fig.add_trace(go.Bar(
+        y = month_data[12:],
+        name = "2021",
+        hoverinfo = "text",
+        hovertext = hovertext_2021,
+        visible = False   
+        ))
+
+
+    fig.update_layout(
+        margin={'t':25},
+        xaxis_title="Year",
+        yaxis_title="Bail amount paid ($)",
+        xaxis_tickvals = [0, 1],
+        xaxis_ticktext = ["2020","2021 YTD"]
+    )
+
+    fig.update_layout(
+        annotations=[
+            dict(text="Select data to view:",
+                 x=-0.5,
+                 y=1.00,
+                 xref="paper",
+                 yref="paper",
+                 align="left",
+                 showarrow=False
+                )
+        ]
+    ) 
+
+    fig.update_layout(
+        updatemenus=[
+            dict(
+                active=0,
+                x = -0.5,
+                xanchor = 'left',
+                y = 0.92,
+                yanchor = 'top',
+                buttons=list([
+                    dict(label="by year",
+                        method="update",
+                        args=[{"visible": [True, True, False, False]},
+                            {'xaxis': {'title': 'year',
+                                        'tickvals' : [0,1],
+                                        'ticktext' : ["2020", "2021 YTD"]
+                            }}]),
+                    dict(label="by month",
+                        method="update",
+                        args=[{"visible": [False, False, True, True]},
+                            {'xaxis': {'title': 'month',
+                                        'tickvals' : list(range(12)),
+                                        'ticktext' : months
+                                        }}
+                            ])
+                        
+                ]),
+            )
+            
+        ])
+
+    f2 = go.FigureWidget(fig)
+    st.plotly_chart(f2)
+
+    # ----------------------------------
+    #  Interactive figure: Neighborhood maps
+    # ----------------------------------       
+    
+    st.subheader('Breakdown by Neighborhood')
     st.write('This section provides an interactive breakdown of case counts, total amounts of bail set and paid, and bail payment rate by Philadelphia zip code, in tandem with income, poverty, and unemployment data from the American Community Survey (ACS) collected by the U.S. Census Bureau.')
     
     st.write('The plot on the left shows bail-related summary for each zipcode, while the plot on the right shows income, poverty level, and unemployment rate for each zipcode. One can see that the neighborhoods that are strongly affected by the bail system often correspond to neighborhoods with low income, high unemployment, and high poverty.')


### PR DESCRIPTION
- Add by-month view of monetary bail frequency to By Year page
- Streamline some page/figure formatting and add explanatory text to make content easier to understand
- Merge "By Price" and "By Neighborhood" into "By Cost to Philadelphians"
- Deduplicate some of the code used to make similar figures